### PR TITLE
ZX-2329 use ref instead of getElementById

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tangelo",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "description": "A presentational table component built in React",
   "license": "MIT",
   "homepage": "https://github.com/mroyce/tangelo",

--- a/src/TableBody.js
+++ b/src/TableBody.js
@@ -28,6 +28,9 @@ class TableBody extends React.Component {
       bodyWidth: 0,
     };
 
+    // Refs
+    this._tableBody = null;
+
     this.handleWindowResize = this.handleWindowResize.bind(this);
   }
 
@@ -80,9 +83,10 @@ class TableBody extends React.Component {
    * for the hidden scrollbar.
    */
   handleWindowResize() {
-    const tableBody = document.getElementById('Tangelo__TableBody');
-    const bodyWidth = tableBody.getBoundingClientRect().width;
-    this.setState({ bodyWidth });
+    if (this._tableBody) {
+      const bodyWidth = this._tableBody.getBoundingClientRect().width;
+      this.setState({ bodyWidth });
+    }
   }
 
   get tableBodyStyle() {
@@ -143,7 +147,7 @@ class TableBody extends React.Component {
         render={sortedRows => (
           <div
             className="Tangelo__TableBody"
-            id="Tangelo__TableBody"
+            ref={ref => { this._tableBody = ref; }}
             style={this.tableBodyStyle}
           >
             <div className="Tangelo__TableBody__ScrollableContent">

--- a/src/styles.css
+++ b/src/styles.css
@@ -79,7 +79,6 @@
   height: 100%;
   margin-right: -30px;
   overflow-y: auto;
-  overscroll-behavior: contain;
   padding-right: 30px;
 }
 


### PR DESCRIPTION
Since there can be multiple instances of Tangelo Table on one page, this ID wasn't unique, so it was always grabbing the first instance of the table on the page. We should just use a ref instead.