### PR TITLE
fix sorting on mount

### DIFF
--- a/src/RowSorterWrapper.js
+++ b/src/RowSorterWrapper.js
@@ -45,6 +45,10 @@ class RowSorterWrapper extends React.Component {
      * @type {Object<string, <TableRow />[]}
      */
     this._orderedRowsMap = {};
+
+    if (this.props.sortingCriteria) {
+      this._constructSortedRows(this.props);
+    }
   }
 
   componentWillReceiveProps(nextProps) {


### PR DESCRIPTION
Currently, the sorting wrapper is setup to calculate and cache the sort order when the props update.

However, this line

https://github.com/mroyce/tangelo/blob/2040c8213411ebb793eb8ddf88d4ef0b294735a3/src/RowSorterWrapper.js#L138

fails if the sortingCriteria is given on mount because the rows haven't been pre-calculated, and it finds a `undefined`, which it can't reverse.

The easy fix for this is to calculate it on mount.

For a more elaborate fix, React actually is deprecating `componentWillReceiveProps` and is recommending a more robust memoization strategy.

https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html#what-about-memoization

We actually are memoizing here, but we may consider either tweaking the implementation to be more idiomatic or integrating a library as suggested