### PR TITLE
Zx 2400 hover active states

### DIFF
--- a/demo/DemoApp.js
+++ b/demo/DemoApp.js
@@ -24,7 +24,6 @@ class DemoApp extends React.Component {
     // <Table /> props
     this.getRowProps = this.getRowProps.bind(this);
     this.shouldRowUpdate = this.shouldRowUpdate.bind(this);
-    this.onRowClick = this.onRowClick.bind(this);
 
     // Cell Renderers
     this.thumbnailCellRenderer = this.thumbnailCellRenderer.bind(this);
@@ -62,10 +61,6 @@ class DemoApp extends React.Component {
   shouldRowUpdate({ currentRowProps, nextRowProps, rowIndex }) {
     // TODO rows don't update when `data` changes
     return currentRowProps.firstNameColor !== nextRowProps.firstNameColor;
-  }
-
-  onRowClick({ rowIndex }) {
-    console.log(rowIndex);
   }
 
   /*****************************
@@ -164,7 +159,6 @@ class DemoApp extends React.Component {
           )}
           getRowProps={this.getRowProps}
           headerHeight={32}
-          onRowClick={this.onRowClick}
           rowCount={this.state.numRows}
           rowHeight={36}
           shouldRowUpdate={this.shouldRowUpdate}

--- a/demo/DemoApp.js
+++ b/demo/DemoApp.js
@@ -24,6 +24,7 @@ class DemoApp extends React.Component {
     // <Table /> props
     this.getRowProps = this.getRowProps.bind(this);
     this.shouldRowUpdate = this.shouldRowUpdate.bind(this);
+    this.onRowClick = this.onRowClick.bind(this);
 
     // Cell Renderers
     this.thumbnailCellRenderer = this.thumbnailCellRenderer.bind(this);
@@ -61,6 +62,10 @@ class DemoApp extends React.Component {
   shouldRowUpdate({ currentRowProps, nextRowProps, rowIndex }) {
     // TODO rows don't update when `data` changes
     return currentRowProps.firstNameColor !== nextRowProps.firstNameColor;
+  }
+
+  onRowClick({ rowIndex }) {
+    console.log(rowIndex);
   }
 
   /*****************************
@@ -159,6 +164,7 @@ class DemoApp extends React.Component {
           )}
           getRowProps={this.getRowProps}
           headerHeight={32}
+          onRowClick={this.onRowClick}
           rowCount={this.state.numRows}
           rowHeight={36}
           shouldRowUpdate={this.shouldRowUpdate}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tangelo",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "description": "A presentational table component built in React",
   "license": "MIT",
   "homepage": "https://github.com/mroyce/tangelo",

--- a/src/TableCell.js
+++ b/src/TableCell.js
@@ -75,20 +75,14 @@ class TableCell extends React.Component {
 
   get eventHandlerProps() {
     const { eventHandlerProps } = this.props;
+
     eventHandlerProps.onMouseOver = pipe(eventHandlerProps.onMouseOver, this.handleShowTooltip);
     eventHandlerProps.onMouseOut = pipe(eventHandlerProps.onMouseOut, this.handleHideTooltip);
+
     return eventHandlerProps;
   }
 
   render() {
-    // Handle highlighting individual cells
-    /*
-    if (!isEmpty(eventHandlerProps)) {
-      eventHandlerProps.onMouseOver = pipe(eventHandlerProps.onMouseOver, this.props.handleChildCellMouseOver);
-      eventHandlerProps.onMouseOut = pipe(eventHandlerProps.onMouseOut, this.props.handleChildCellMouseOut);
-    }
-    */
-
     return (
       <div
         className={classNames(

--- a/src/TableCell.js
+++ b/src/TableCell.js
@@ -2,11 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
+import withEventHandlers from './withEventHandlers';
 import {
-  getEventHandlerProps,
-  getIsClickable,
   isEmpty,
-  noop,
   pipe,
 } from './utils';
 
@@ -57,6 +55,12 @@ class TableCell extends React.Component {
     return this.content.scrollWidth > this.content.clientWidth;
   }
 
+  get isEmpty() {
+    return Array.isArray(this.props.children) ?
+      !this.props.children.some(c => c) :
+      !this.props.children;
+  }
+
   get style() {
     const {
       align,
@@ -69,26 +73,21 @@ class TableCell extends React.Component {
     };
   }
 
-  render() {
-    const {
-      align,
-      children,
-      columnIndex,
-      rowIndex,
-      tooltip,
-    } = this.props;
+  get eventHandlerProps() {
+    const { eventHandlerProps } = this.props;
+    eventHandlerProps.onMouseOver = pipe(eventHandlerProps.onMouseOver, this.handleShowTooltip);
+    eventHandlerProps.onMouseOut = pipe(eventHandlerProps.onMouseOut, this.handleHideTooltip);
+    return eventHandlerProps;
+  }
 
+  render() {
     // Handle highlighting individual cells
-    const eventHandlerProps = getEventHandlerProps(this, { columnIndex, rowIndex });
-    const highlightable = !isEmpty(eventHandlerProps);
+    /*
     if (!isEmpty(eventHandlerProps)) {
       eventHandlerProps.onMouseOver = pipe(eventHandlerProps.onMouseOver, this.props.handleChildCellMouseOver);
       eventHandlerProps.onMouseOut = pipe(eventHandlerProps.onMouseOut, this.props.handleChildCellMouseOut);
     }
-
-    // Handle showing/hiding tooltip
-    eventHandlerProps.onMouseOver = pipe(eventHandlerProps.onMouseOver, this.handleShowTooltip);
-    eventHandlerProps.onMouseOut = pipe(eventHandlerProps.onMouseOut, this.handleHideTooltip);
+    */
 
     return (
       <div
@@ -97,25 +96,23 @@ class TableCell extends React.Component {
           this.props.className,
           {
             'Tangelo__TableCell--hide-right-border': this.props.hideRightBorder,
-            'Tangelo__TableCell--empty': Array.isArray(children) ? !children.some(c => c) : !children,
-            'Tangelo__TableCell--highlightable': highlightable,
-            'Tangelo__TableCell--clickable': getIsClickable(this),
+            'Tangelo__TableCell--empty': this.isEmpty,
           }
         )}
         style={this.style}
-        {...eventHandlerProps}
+        {...this.eventHandlerProps}
       >
         <div
           className="Tangelo__TableCell__Content"
           ref={ref => {this.content = ref; }}
         >
-          {children}
+          {this.props.children}
           {isEmpty(this.props.icons) || (
             <div
               className={classNames(
                 "Tangelo__TableCell__IconsSection",
                 {
-                  'Tangelo__TableCell__IconsSection--left': align === "right",
+                  'Tangelo__TableCell__IconsSection--left': this.props.align === "right",
                 }
               )}
             >
@@ -163,6 +160,17 @@ TableCell.propTypes = {
   columnIndex: PropTypes.number.isRequired,
 
   /**
+   * from `withEventHandlers`
+   */
+  eventHandlerProps: PropTypes.shape({
+    onClick: PropTypes.func,
+    onDoubleClick: PropTypes.func,
+    onMouseOut: PropTypes.func,
+    onMouseOver: PropTypes.func,
+    onRightClick: PropTypes.func,
+  }).isRequired,
+
+  /**
    *
    */
   flexStyle: PropTypes.oneOfType([
@@ -187,31 +195,6 @@ TableCell.propTypes = {
   /**
    *
    */
-  onClick: PropTypes.func,
-
-  /**
-   *
-   */
-  onDoubleClick: PropTypes.func,
-
-  /**
-   *
-   */
-  onMouseOut: PropTypes.func,
-
-  /**
-   *
-   */
-  onMouseOver: PropTypes.func,
-
-  /**
-   *
-   */
-  onRightClick: PropTypes.func,
-
-  /**
-   *
-   */
   rowIndex: PropTypes.number.isRequired,
 };
 
@@ -219,14 +202,12 @@ TableCell.defaultProps = {
   children: null,
   className: '',
   hideRightBorder: false,
-  onClick: null,
-  onDoubleClick: null,
-  onMouseOut: null,
-  onMouseOver: null,
-  onRightClick: null,
 };
 
 TableCell.displayName = 'TangeloTableCell';
 
 
-export default TableCell;
+export default withEventHandlers(TableCell, ownProps => ({
+  columnIndex: ownProps.columnIndex,
+  rowIndex: ownProps.rowIndex,
+}));

--- a/src/TableRow.js
+++ b/src/TableRow.js
@@ -2,11 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
+import withEventHandlers from './withEventHandlers';
 import TableCell from './TableCell';
 import {
   getEventHandlerProps,
   getIsClickable,
   pickProps,
+  pipe,
 } from './utils';
 
 
@@ -17,14 +19,6 @@ class TableRow extends React.Component {
 
     // <number: columnIndex, Element: <TableCell />>
     this._cellCache = {};
-
-    this.state = {
-      // If a child cell is highlighted, we shouldn't highlight the row
-      isChildCellHighlighted: false,
-    };
-
-    this.handleChildCellMouseOver = this.handleChildCellMouseOver.bind(this);
-    this.handleChildCellMouseOut = this.handleChildCellMouseOut.bind(this);
   }
 
   componentWillMount() {
@@ -47,22 +41,13 @@ class TableRow extends React.Component {
     }
   }
 
-  handleChildCellMouseOver() {
-    this.setState({ isChildCellHighlighted: true });
-  }
-
-  handleChildCellMouseOut() {
-    this.setState({ isChildCellHighlighted: false });
-  }
-
   _constructCells(props) {
     const {
-      columns,
       rowIndex,
     } = props;
 
     // TODO optimize so we only render cells that are in view
-    columns.forEach((column, columnIndex) => {
+    this.props.columns.forEach((column, columnIndex) => {
       const className = 
         typeof column.columnClassName === 'function' ?
         column.columnClassName({ columnIndex, rowIndex }) :
@@ -83,6 +68,16 @@ class TableRow extends React.Component {
           column.tooltip({ columnIndex, rowIndex }) :
           column.tooltip;
 
+      const onMouseOver =
+        getIsClickable(column) ?
+        pipe(column.onCellMouseOver, this.props.handleClickableChildMouseOver) :
+        column.onCellMouseOver;
+
+      const onMouseOut =
+        getIsClickable(column) ?
+        pipe(column.onCellMouseOut, this.props.handleClickableChildMouseOut) :
+        column.onCellMouseOut;
+
       this._cellCache[columnIndex] = (
         <TableCell
           {...pickProps(column, [
@@ -98,8 +93,8 @@ class TableRow extends React.Component {
           icons={icons}
           onClick={column.onCellClick}
           onDoubleClick={column.onCellDoubleClick}
-          onMouseOut={column.onCellMouseOut}
-          onMouseOver={column.onCellMouseOver}
+          onMouseOut={onMouseOut}
+          onMouseOver={onMouseOver}
           onRightClick={column.onCellRightClick}
           rowIndex={rowIndex}
           tooltip={tooltip}
@@ -111,23 +106,17 @@ class TableRow extends React.Component {
   }
 
   render() {
-    const {
-      rowIndex,
-    } = this.props;
-
     return (
       <div
         className={classNames(
           "Tangelo__TableRow",
           this.props.className,
           {
-            'Tangelo__TableRow--highlight-disabled': this.state.isChildCellHighlighted,
-            'Tangelo__TableRow--clickable': getIsClickable(this),
             'Tangelo__TableRow--hide-border-bottom': this.props.hideBorderBottom,
           }
         )}
         style={this.rowStyle}
-        {...getEventHandlerProps(this, { rowIndex })}
+        {...this.props.eventHandlerProps}
       >
         {Object.values(this._cellCache)}
       </div>
@@ -175,34 +164,20 @@ TableRow.propTypes = {
   ).isRequired,
 
   /**
+   * from `withEventHandlers`
+   */
+  eventHandlerProps: PropTypes.shape({
+    onClick: PropTypes.func,
+    onDoubleClick: PropTypes.func,
+    onMouseOut: PropTypes.func,
+    onMouseOver: PropTypes.func,
+    onRightClick: PropTypes.func,
+  }).isRequired,
+
+  /**
    *
    */
   hideBorderBottom: PropTypes.bool,
-
-  /**
-   *
-   */
-  onClick: PropTypes.func,
-
-  /**
-   *
-   */
-  onDoubleClick: PropTypes.func,
-
-  /**
-   *
-   */
-  onMouseOut: PropTypes.func,
-
-  /**
-   *
-   */
-  onMouseOver: PropTypes.func,
-
-  /**
-   *
-   */
-  onRightClick: PropTypes.func,
 
   /**
    *
@@ -218,15 +193,10 @@ TableRow.propTypes = {
 TableRow.defaultProps = {
   className: '',
   hideBorderBottom: false,
-  onClick: null,
-  onDoubleClick: null,
-  onMouseOut: null,
-  onMouseOver: null,
-  onRightClick: null,
   selected: false,
 };
 
 TableRow.displayName = 'TangeloTableRow';
 
 
-export default TableRow;
+export default withEventHandlers(TableRow, ownProps => ({ rowIndex: ownProps.rowIndex }));

--- a/src/TableRow.js
+++ b/src/TableRow.js
@@ -5,7 +5,6 @@ import classNames from 'classnames';
 import withEventHandlers from './withEventHandlers';
 import TableCell from './TableCell';
 import {
-  getEventHandlerProps,
   getIsClickable,
   pickProps,
   pipe,

--- a/src/styles.css
+++ b/src/styles.css
@@ -19,10 +19,6 @@
   flex-direction: row;
 }
 
-.Tangelo__TableRow--clickable:not(.Tangelo__TableRow--highlight-disabled) {
-  cursor: pointer;
-}
-
 .Tangelo__TableRow:last-child,
 .Tangelo__TableRow--hide-border-bottom {
   border-bottom: none;
@@ -45,24 +41,16 @@
   width: 100%;
 }
 
-.Tangelo__TableRow--header:hover:not(.Tangelo__TableRow--highlight-disabled) {
-  background-color: rgba(0, 0, 0, 0.1);
-}
-
-.Tangelo__TableRow--header:active:not(.Tangelo__TableRow--highlight-disabled) {
-  background-color: rgba(0, 0, 0, 0.15);
-}
-
 /* Sort Arrow */
 .Tangelo__HeaderSortArrow {
   opacity: 0.6;
 }
 
-.Tangelo__TableCell--highlightable:hover .Tangelo__HeaderSortArrow {
+.Tangelo__TableCell:hover .Tangelo__HeaderSortArrow {
   opacity: 0.8;
 }
 
-.Tangelo__TableCell--highlightable:active .Tangelo__HeaderSortArrow {
+.Tangelo__TableCell:active .Tangelo__HeaderSortArrow {
   opacity: 1;
 }
 
@@ -109,14 +97,6 @@
   font-size: 16px;
 }
 
-.Tangelo__TableRow--body:hover:not(.TableRow--highlight-disabled) {
-  background-color: rgba(0, 0, 0, 0.05);
-}
-
-.Tangelo__TableRow--body:active:not(.TableRow--highlight-disabled) {
-  background-color: rgba(0, 0, 0, 0.1);
-}
-
 /* TODO not implemented yet */
 /*
 .Tangelo__TableRow--selected {
@@ -141,18 +121,6 @@
 
 .Tangelo__TableCell * {
   vertical-align: middle;
-}
-
-.Tangelo__TableCell--highlightable:hover {
-  background-color: rgba(0, 0, 0, 0.05);
-}
-
-.Tangelo__TableCell--highlightable:active {
-  background-color: rgba(0, 0, 0, 0.1);
-}
-
-.Tangelo__TableCell--clickable {
-  cursor: pointer;
 }
 
 .Tangelo__TableCell--empty,
@@ -203,4 +171,20 @@
   text-align: center;
   transform: translateX(-50%);
   white-space: nowrap;
+}
+
+
+/*******************************
+ * withEventHandlers modifiers *
+ *******************************/
+.--clickable {
+  cursor: pointer;
+}
+
+.--clickable:not(.--clickable--disable-highlight):hover {
+  background-color: rgba(0, 0, 0, 0.1);
+}
+
+.--clickable:not(.--clickable--disable-highlight):active {
+  background-color: rgba(0, 0, 0, 0.15);
 }

--- a/src/utils/getEventHandlerProps.js
+++ b/src/utils/getEventHandlerProps.js
@@ -2,7 +2,7 @@ import noop from './noop';
 
 /**
  * Passes in additional contextual parameters to event handlers.
- * Used by <TableRow /> and <TableCell /> to pass in `rowIndex` and `columnIndex` as params.
+ * Used by `withEventHandlers` to pass in `rowIndex` and `columnIndex` as params to the handlers.
  *
  * @param {Object} props
  * @param {Object} [parameters={}]

--- a/src/utils/getEventHandlerProps.js
+++ b/src/utils/getEventHandlerProps.js
@@ -1,11 +1,14 @@
 import noop from './noop';
 
 /**
- * @param {React.Component} component
+ * Passes in additional contextual parameters to event handlers.
+ * Used by <TableRow /> and <TableCell /> to pass in `rowIndex` and `columnIndex` as params.
+ *
+ * @param {Object} props
  * @param {Object} [parameters={}]
  * @returns {Object}
  */
-export default (component, parameters = {}) => {
+export default (props, parameters = {}) => {
   const createEventHandler = handler => event => {
     handler({ event, ...parameters });
     event.stopPropagation();
@@ -17,7 +20,7 @@ export default (component, parameters = {}) => {
     onMouseOut,
     onMouseOver,
     onRightClick,
-  } = component.props;
+  } = props;
 
   const eventHandlerProps = {};
 

--- a/src/utils/getIsClickable.js
+++ b/src/utils/getIsClickable.js
@@ -4,15 +4,19 @@ import noop from './noop';
 /**
  * Returns true if the component has any onClick, onDoubleClick, or onRightClick props.
  *
- * @param {React.Component} component
+ * @param {Object} props
  * @returns {Boolean}
  */
-export default component => {
+export default props => {
   const {
     onClick,
     onDoubleClick,
     onRightClick,
-  } = component.props;
+
+    onCellClick,
+    onCellDoubleClick,
+    onCellRightClick,
+  } = props;
 
   if (onClick && onClick !== noop) {
     return true;
@@ -24,7 +28,19 @@ export default component => {
 
   if (onRightClick && onRightClick !== noop) {
     return true;
-  }          
+  }
+
+  if (onCellClick && onCellClick !== noop) {
+    return true;
+  }
+
+  if (onCellDoubleClick && onCellDoubleClick !== noop) {
+    return true;
+  }
+
+  if (onCellRightClick && onCellRightClick !== noop) {
+    return true;
+  }
 
   return false;
 };  

--- a/src/withEventHandlers.js
+++ b/src/withEventHandlers.js
@@ -1,0 +1,96 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+import {
+  getEventHandlerProps,
+  getIsClickable,
+} from './utils';
+
+
+/**
+ *
+ */
+export default (ComposedComponent, parameters) => {
+  class withEventHandlers extends React.Component {
+    constructor(...args) {
+      super(...args);
+
+      this.state = {
+        // If a child of a clickable element is highlighted, then the parent should not be highlighted
+        isClickableChildHighlighted: false,
+      };
+
+      this.handleClickableChildMouseOver = this.handleClickableChildMouseOver.bind(this);
+      this.handleClickableChildMouseOut = this.handleClickableChildMouseOut.bind(this);
+    }
+
+    handleClickableChildMouseOver() {
+      this.setState({ isClickableChildHighlighted: true });
+      console.log('MUDDA OVER');
+    }
+
+    handleClickableChildMouseOut() {
+      this.setState({ isClickableChildHighlighted: false });
+      console.log('MUDDA OUT');
+    }
+
+    render() {
+      const eventHandlerProps = getEventHandlerProps(this.props, parameters(this.props));
+      const className = classNames(
+        this.props.className,
+        {
+          '--clickable': getIsClickable(eventHandlerProps),
+          '--clickable--disable-highlight': this.state.isClickableChildHighlighted,
+        }
+      );
+
+      console.log(this.state);
+      console.log(className);
+
+      return (
+        <ComposedComponent
+          {...this.props}
+          className={className}
+          eventHandlerProps={eventHandlerProps}
+          handleClickableChildMouseOver={this.handleClickableChildMouseOver}
+          handleClickableChildMouseOut={this.handleClickableChildMouseOut}
+        />
+      );
+    }
+  }
+
+  withEventHandlers.propTypes = {
+    /**
+     *
+     */
+    className: PropTypes.string,
+
+    /**
+     *
+     */
+    onClick: PropTypes.func,
+  
+    /**
+     *
+     */
+    onDoubleClick: PropTypes.func,
+  
+    /**
+     *
+     */
+    onMouseOut: PropTypes.func,
+  
+    /**
+     *
+     */
+    onMouseOver: PropTypes.func,
+  
+    /**
+     *
+     */
+    onRightClick: PropTypes.func,
+  };
+
+  return withEventHandlers;
+};

--- a/src/withEventHandlers.js
+++ b/src/withEventHandlers.js
@@ -5,11 +5,17 @@ import classNames from 'classnames';
 import {
   getEventHandlerProps,
   getIsClickable,
+  noop,
 } from './utils';
 
 
 /**
+ * Passes in event handler props and clickable modifier classNames to components
+ * with event handler props.
  *
+ * @param {React.Component} ComposedComponent
+ * @param {Function} parameters
+ * @returns {React.Component}
  */
 export default (ComposedComponent, parameters) => {
   class withEventHandlers extends React.Component {
@@ -27,12 +33,10 @@ export default (ComposedComponent, parameters) => {
 
     handleClickableChildMouseOver() {
       this.setState({ isClickableChildHighlighted: true });
-      console.log('MUDDA OVER');
     }
 
     handleClickableChildMouseOut() {
       this.setState({ isClickableChildHighlighted: false });
-      console.log('MUDDA OUT');
     }
 
     render() {
@@ -44,9 +48,6 @@ export default (ComposedComponent, parameters) => {
           '--clickable--disable-highlight': this.state.isClickableChildHighlighted,
         }
       );
-
-      console.log(this.state);
-      console.log(className);
 
       return (
         <ComposedComponent
@@ -90,6 +91,15 @@ export default (ComposedComponent, parameters) => {
      *
      */
     onRightClick: PropTypes.func,
+  };
+
+  withEventHandlers.defaultProps = {
+    className: '',
+    onClick: noop,
+    onDoubleClick: noop,
+    onMouseOut: noop,
+    onMouseOver: noop,
+    onRightClick: noop,
   };
 
   return withEventHandlers;


### PR DESCRIPTION
Hover state on tables without any click action is deceptive. I expect to be able to click in for more detail with that hover state, especially with active state as well.

For Header:
* Only show hover/active states for clickable cells
* Never show hover/active state for entire row
![screen shot 2018-08-07 at 4 23 55 pm](https://user-images.githubusercontent.com/4933374/43808056-0d614756-9a60-11e8-8bc2-fdac146e01ce.png)
![screen shot 2018-08-07 at 4 24 02 pm](https://user-images.githubusercontent.com/4933374/43808057-0d8c98ca-9a60-11e8-8960-1df65a4a4258.png)


For Row:
* Only show active state for clickable rows
* Always show hover state for entire row
![screen shot 2018-08-07 at 4 23 43 pm](https://user-images.githubusercontent.com/4933374/43808061-10e47222-9a60-11e8-8824-e0caaa518a31.png)
![screen shot 2018-08-07 at 4 23 49 pm](https://user-images.githubusercontent.com/4933374/43808062-10fe0354-9a60-11e8-8002-c4092976744d.png)
