### PR TITLE
ColumnProps base prop types

### DIFF
--- a/src/TableHeaderRow.js
+++ b/src/TableHeaderRow.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
+import ColumnProps from './prop-types/ColumnProps';
 import HeaderSortArrow from './HeaderSortArrow';
 import TableRow from './TableRow';
 import { SortDirection } from './constants';
@@ -66,38 +67,8 @@ TableHeaderRow.propTypes = {
 
   /**
    *
-   * TODO create types for columns
    */
-  columns: PropTypes.arrayOf(
-    PropTypes.shape({
-      align: PropTypes.oneOf([
-        'left',
-        'right',
-        'center',
-      ]),
-      columnClassName: PropTypes.oneOfType([
-        PropTypes.string,
-        PropTypes.func,
-      ]),
-      cellRenderer: PropTypes.oneOfType([
-        PropTypes.node,
-        PropTypes.func,
-      ]),
-      flexStyle: PropTypes.oneOfType([
-        PropTypes.shape({
-          flexBasis: PropTypes.string,
-        }),
-        PropTypes.shape({
-          flex: PropTypes.string,
-        }),
-      ]),
-      onCellClick: PropTypes.func,
-      onCellDoubleClick: PropTypes.func,
-      onCellMouseOut: PropTypes.func,
-      onCellMouseOver: PropTypes.func,
-      onCellRightClick: PropTypes.func,
-    })
-  ).isRequired,
+  columns: PropTypes.arrayOf(ColumnProps).isRequired,
 
   /**
    *

--- a/src/TableRow.js
+++ b/src/TableRow.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import withEventHandlers from './hocs/withEventHandlers';
+import ColumnProps from './prop-types/ColumnProps';
 import TableCell from './TableCell';
 import {
   getIsClickable,
@@ -21,12 +22,12 @@ class TableRow extends React.Component {
   }
 
   componentWillMount() {
-    this._constructCells(this.props);
+    this._constructCells(this.props.rowIndex, this.props.columns);
   }
 
   componentWillUpdate(nextProps) {
     // TODO consider only updating some cells like we do for rows in `TableBody`
-    this._constructCells(nextProps);
+    this._constructCells(nextProps.rowIndex, nextProps.columns);
   }
 
   get rowStyle() {
@@ -40,13 +41,9 @@ class TableRow extends React.Component {
     }
   }
 
-  _constructCells(props) {
-    const {
-      rowIndex,
-    } = props;
-
+  _constructCells(rowIndex, columns) {
     // TODO optimize so we only render cells that are in view
-    this.props.columns.forEach((column, columnIndex) => {
+    columns.forEach((column, columnIndex) => {
       const className = 
         typeof column.columnClassName === 'function' ?
         column.columnClassName({ columnIndex, rowIndex }) :
@@ -132,35 +129,7 @@ TableRow.propTypes = {
   /**
    *
    */
-  columns: PropTypes.arrayOf(
-    PropTypes.shape({
-      align: PropTypes.oneOf([
-        'left',
-        'right',
-        'center',
-      ]),
-      columnClassName: PropTypes.oneOfType([
-        PropTypes.string,
-        PropTypes.func,
-      ]),
-      cellRenderer: PropTypes.oneOfType([
-        PropTypes.node,
-        PropTypes.func,
-      ]),
-      flexStyle: PropTypes.oneOfType([
-        PropTypes.shape({
-          flexBasis: PropTypes.string,
-        }),
-        PropTypes.shape({
-          flex: PropTypes.string,
-        }),
-      ]).isRequired,
-      icons: PropTypes.oneOfType([
-        PropTypes.arrayOf(PropTypes.element),
-        PropTypes.func,
-      ]),
-    })
-  ).isRequired,
+  columns: PropTypes.arrayOf(ColumnProps).isRequired,
 
   /**
    * from `withEventHandlers`

--- a/src/hocs/withEventHandlers.js
+++ b/src/hocs/withEventHandlers.js
@@ -6,7 +6,7 @@ import {
   getEventHandlerProps,
   getIsClickable,
   noop,
-} from './utils';
+} from '../utils';
 
 
 /**

--- a/src/prop-types/ColumnProps.js
+++ b/src/prop-types/ColumnProps.js
@@ -1,0 +1,125 @@
+import PropTypes from 'prop-types';
+
+
+export default {
+  /**
+   * Alignment of content for cells in this column.
+   */
+  align: PropTypes.oneOf([
+    'left',
+    'right',
+    'center',
+  ]),
+
+  /**
+   * ``className`` that will be applied to cells in this column.
+   *
+   * Accepts the following parameters:
+   * {
+   *   columnIndex,
+   *   rowIndex,
+   * }
+   */
+  columnClassName: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.func,
+  ]),
+
+  /**
+   * The content that will be displayed for cells in this column.
+   *
+   * Accepts the following parameters:
+   * {
+   *   columnIndex,
+   *   rowIndex, (if table body cell)
+   * }
+   */
+  cellRenderer: PropTypes.oneOfType([
+    PropTypes.node,
+    PropTypes.func,
+  ]),
+
+  /**
+   * Flex styles to apply to cells in this column.
+   *
+   * Percent widths use flex-basis, pixel widths use flex.
+   */
+  flexStyle: PropTypes.oneOfType([
+    PropTypes.shape({
+      flexBasis: PropTypes.string,
+    }),
+    PropTypes.shape({
+      flex: PropTypes.string,
+    }),
+  ]).isRequired,
+
+  /**
+   * An array of SVG elements or a function that returns an array of SVG elements
+   * which will be displayed in the bottom-right-hand corner of the cell.
+   * All SVGs are scaled to 16x16 pixels.
+   *
+   * Accepts the following parameters:
+   * {
+   *   rowIndex,
+   * }
+   */
+  icons: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.element),
+    PropTypes.func,
+  ]),
+
+  /**
+   * Function that is called with a cell is clicked.
+   *
+   * Accepts the following parameters:
+   * {
+   *   columnIndex,
+   *   rowIndex,
+   * }
+   */
+  onCellClick: PropTypes.func,
+
+  /**
+   * Function that is called when a cell is double clicked.
+   *
+   * Accepts the following parameters:
+   * {
+   *   columnIndex,
+   *   rowIndex,
+   * }
+   */
+  onCellDoubleClick: PropTypes.func,
+
+  /**
+   * Function that is called when the user's cursor leaves a cell.
+   *
+   * Accepts the following parameters:
+   * {
+   *   columnIndex,
+   *   rowIndex,
+   * }
+   */
+  onCellMouseOut: PropTypes.func,
+
+  /**
+   * Function that is called when the user's cursor enters a cell.
+   *
+   * Accepts the following parameters:
+   * {
+   *   columnIndex,
+   *   rowIndex,
+   * }
+   */
+  onCellMouseOver: PropTypes.func,
+
+  /**
+   * Function that is called when a cell is right clicked.
+   *
+   * Accepts the following parameters:
+   * {
+   *   columnIndex,
+   *   rowIndex,
+   * }
+   */
+  onCellRightClick: PropTypes.func,
+};


### PR DESCRIPTION
`ColumnProps` so we aren't repeating prop type declarations in multiple places.