### PR TITLE
ZX-2874 clear cached cells on update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tangelo",
-  "version": "0.0.28",
+  "version": "0.0.30",
   "description": "A presentational table component built in React",
   "license": "MIT",
   "homepage": "https://github.com/mroyce/tangelo",

--- a/src/TableRow.js
+++ b/src/TableRow.js
@@ -33,6 +33,7 @@ class TableRow extends React.Component {
 
   componentWillUpdate(nextProps) {
     // TODO consider only updating some cells like we do for rows in `TableBody`
+    this._cellCache = {};
     this._constructCells(nextProps);
   }
 


### PR DESCRIPTION
Clearing cell cache on update to avoid extra unwanted cells. Have another ticket to reuse cached cells for performance improvements, but this is a fine hotfix for now.