### PR TITLE
 added support for trailing icons in all alignments

### DIFF
--- a/cypress/app/styles.css
+++ b/cypress/app/styles.css
@@ -250,3 +250,15 @@
   transform: translateX(-50%);
   white-space: nowrap;
 }
+
+.Tangelo__TableCell__TrailingIconWrapper--left {
+  margin-right: 12px;
+}
+
+.Tangelo__TableCell__TrailingIconWrapper {
+  display: inline-block;
+  margin-left: 12px;
+  height: 16px;
+  line-height: 16px;
+  width: 16px;
+}

--- a/demo/DemoApp.js
+++ b/demo/DemoApp.js
@@ -305,6 +305,11 @@ class DemoApp extends React.Component {
               sortBy="person.lastName"
               width={120}
               widthType="px"
+              trailingIcons={({ rowIndex }) =>
+                this.state.data[rowIndex].email.includes('gmail') ?
+                [<MailIcon />] :
+                null
+              }
             />
             <TableColumn
               key="address"

--- a/src/Table.js
+++ b/src/Table.js
@@ -87,6 +87,7 @@ class Table extends React.Component {
         'onCellMouseOver',
         'onCellRightClick',
         'tooltip',
+        'trailingIcons',
       ]),
       cellRenderer: column.props.bodyCellRenderer,
       flexStyle: getFlexStyle(column.props.width, column.props.widthType),

--- a/src/TableBody.js
+++ b/src/TableBody.js
@@ -104,7 +104,7 @@ class TableBody extends React.Component {
    */
   handleTableScroll() {
     if (!this.props.paginationLoading && this.props.paginationFunc) {
-	  const {
+    const {
         distanceFromBottom,
       } = getElementScrollInfo(this._scrollRef.current);
       const paginationDistanceBuffer = this.props.rowHeight * this.props.paginationRowCountBuffer;
@@ -236,6 +236,10 @@ TableBody.propTypes = {
         }),
       ]),
       icons: PropTypes.oneOfType([
+        PropTypes.arrayOf(PropTypes.element),
+        PropTypes.func,
+      ]),
+      trailingIcons: PropTypes.oneOfType([
         PropTypes.arrayOf(PropTypes.element),
         PropTypes.func,
       ]),

--- a/src/TableBodyRow.js
+++ b/src/TableBodyRow.js
@@ -69,6 +69,10 @@ TableBodyRow.propTypes = {
         PropTypes.arrayOf(PropTypes.element),
         PropTypes.func,
       ]),
+      trailingIcons: PropTypes.oneOfType([
+        PropTypes.arrayOf(PropTypes.element),
+        PropTypes.func,
+      ]),
     })
   ).isRequired,
 

--- a/src/TableCell.js
+++ b/src/TableCell.js
@@ -52,7 +52,23 @@ const TableCell = props => {
         className="Tangelo__TableCell__Content"
         ref={content}
       >
-        {props.children}
+        {isEmpty(props.trailingIcons) || props.align !== 'right' || props.trailingIcons.map((icon, idx) => (
+          <div
+            className="Tangelo__TableCell__TrailingIconWrapper Tangelo__TableCell__TrailingIconWrapper--left"
+            key={`table_trailingicon_${rowIndex}_${columnIndex}_${idx}`}
+          >
+            {icon}
+          </div>
+        ))}
+        <span>{props.children}</span>
+        {isEmpty(props.trailingIcons) || props.align === 'right' || props.trailingIcons.map((icon, idx) => (
+          <div
+            className="Tangelo__TableCell__TrailingIconWrapper"
+            key={`table_trailingicon_${rowIndex}_${columnIndex}_${idx}`}
+          >
+            {icon}
+          </div>
+        ))}
       </div>
       {isEmpty(props.icons) || (
         <div
@@ -175,6 +191,11 @@ TableCell.propTypes = {
    *
    */
   tooltip: PropTypes.node,
+
+  /**
+   *
+   */
+  trailingIcons: PropTypes.arrayOf(PropTypes.element),
 };
 
 TableCell.defaultProps = {

--- a/src/TableColumn.js
+++ b/src/TableColumn.js
@@ -171,6 +171,21 @@ TableColumn.propTypes = {
     PropTypes.func,
   ]),
 
+   /**
+   * An array of SVG elements or a function that returns an array of SVG elements
+   * which will be displayed beside the label in table cell
+   * All SVGs will be scaled to 16x16 pixels.
+   *
+   * Accepts the following parameters:
+   * {
+   *   rowIndex,
+   * }
+   */
+  trailingIcons: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.element),
+    PropTypes.func,
+  ]),
+
   /**
    * The width of the cells in this column in pixels or percentage.
    */
@@ -200,6 +215,7 @@ TableColumn.defaultProps = {
   onCellRightClick: noop,
   sortBy: null,
   tooltip: null,
+  trailingIcons: [],
   widthType: '%',
 };
 

--- a/src/TableRow.js
+++ b/src/TableRow.js
@@ -76,6 +76,11 @@ class TableRow extends React.Component {
             typeof column.tooltip === 'function' ?
               column.tooltip({ columnIndex, rowIndex }) :
               column.tooltip;
+            
+          const trailingIcons =
+            typeof column.trailingIcons === 'function' ?
+              column.trailingIcons( { columnIndex, rowIndex }) :
+              column.trailingIcons;
 
           return (
             <TableCell
@@ -97,6 +102,7 @@ class TableRow extends React.Component {
               onRightClick={column.onCellRightClick}
               rowIndex={rowIndex}
               tooltip={tooltip}
+              trailingIcons={trailingIcons}
             >
               {cellContent}
             </TableCell>
@@ -140,6 +146,10 @@ TableRow.propTypes = {
         }),
       ]).isRequired,
       icons: PropTypes.oneOfType([
+        PropTypes.arrayOf(PropTypes.element),
+        PropTypes.func,
+      ]),
+      trailingIcons: PropTypes.oneOfType([
         PropTypes.arrayOf(PropTypes.element),
         PropTypes.func,
       ]),

--- a/src/styles.css
+++ b/src/styles.css
@@ -250,3 +250,15 @@
   text-align: center;
   white-space: nowrap;
 }
+
+.Tangelo__TableCell__TrailingIconWrapper--left {
+  margin-right: 12px;
+}
+
+.Tangelo__TableCell__TrailingIconWrapper {
+  display: inline-block;
+  margin-left: 12px;
+  height: 16px;
+  line-height: 16px;
+  width: 16px;
+}


### PR DESCRIPTION
Looks something like this for alignment left/center

![Screen Shot 2019-11-06 at 12 50 27 PM](https://user-images.githubusercontent.com/28584032/68336894-35715100-0094-11ea-95be-d2a0f544650a.png)


alignment right

![Screen Shot 2019-11-06 at 12 51 17 PM](https://user-images.githubusercontent.com/28584032/68336905-386c4180-0094-11ea-980b-0642ae96ea0a.png)
