### PR TITLE
ZX-6053

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tangelo",
-  "version": "0.0.44",
+  "version": "0.0.47",
   "description": "A presentational table component built in React",
   "license": "MIT",
   "homepage": "https://github.com/mroyce/tangelo",

--- a/src/TableBody.js
+++ b/src/TableBody.js
@@ -104,7 +104,7 @@ class TableBody extends React.Component {
    */
   handleTableScroll() {
     if (!this.props.paginationLoading && this.props.paginationFunc) {
-	  const {
+      const {
         distanceFromBottom,
       } = getElementScrollInfo(this._scrollRef.current);
       const paginationDistanceBuffer = this.props.rowHeight * this.props.paginationRowCountBuffer;
@@ -128,7 +128,7 @@ class TableBody extends React.Component {
 
     return {
       height: this.props.rowCount * (this.props.rowHeight + borderHeight),
-      width: this.state.bodyWidth || '100%',
+      width: 'calc(100% + 15px)',
     };
   }
 


### PR DESCRIPTION
Update table wrapper width to be `calc(100% + 15px)`. We set the width here manually because we account for the additional width of the scrollbar which we hide by sliding to the right. Since the scrollbar is 15px we calculate the width to be 100% + 15px.