### PR TITLE
ZX-6298 fix table width misalignment

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tangelo",
-  "version": "0.0.47",
+  "version": "0.0.48",
   "description": "A presentational table component built in React",
   "license": "MIT",
   "homepage": "https://github.com/mroyce/tangelo",

--- a/src/TableBody.js
+++ b/src/TableBody.js
@@ -128,7 +128,7 @@ class TableBody extends React.Component {
 
     return {
       height: this.props.rowCount * (this.props.rowHeight + borderHeight),
-      width: 'calc(100% + 15px)',
+      width: '100%',
     };
   }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -80,6 +80,12 @@
   margin-right: -30px;
   overflow-y: auto;
   padding-right: 30px;
+  -ms-overflow-style: -ms-autohiding-scrollbar;
+  scrollbar-width: none;  /* supported in FF 81 */
+}
+
+Tangelo__TableBody__ScrollableContent::-webkit-scrollbar {
+  display: none;  /* supported in Chrome 85 */
 }
 
 .Tangelo__TableBody__ScrollableContent__Loader {


### PR DESCRIPTION
I tested this in:

* Windows Firefox
* Windows Chrome
* Windows Edge
* OSX Firefox
* OSX Chrome
* OSX Safari

And in OSX, I tested both with scrollbars always shown and not.
