### PR TITLE
ZX-6861 use spread syntax instead of argument keyword

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tangelo",
-  "version": "0.0.49",
+  "version": "0.0.50",
   "description": "A presentational table component built in React",
   "license": "MIT",
   "homepage": "https://github.com/mroyce/tangelo",

--- a/src/utils/debounce.js
+++ b/src/utils/debounce.js
@@ -4,9 +4,8 @@
  */
 export default (func, wait, immediate) => {
   let timeout;
-  return () => {
+  return (...args) => {
     const context = this;
-    const args = arguments;
     const later = () => {
       timeout = null;
       if (!immediate) func.apply(context, args);


### PR DESCRIPTION
Using spread syntax instead of `argument` keyword