### PR TITLE
Remove noop usages in TableColumn.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tangelo",
-  "version": "0.0.59",
+  "version": "0.0.60",
   "description": "A presentational table component built in React",
   "license": "MIT",
   "homepage": "https://github.com/mroyce/tangelo",

--- a/src/TableColumn.js
+++ b/src/TableColumn.js
@@ -1,9 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { noop } from './utils';
-
-
 class TableColumn extends React.Component {
   render() {
     if (process.env.NODE_ENV !== 'production') {
@@ -193,11 +190,11 @@ TableColumn.defaultProps = {
   hideRightBorder: false,
   icons: [],
   minWidth: null,
-  onCellClick: noop,
-  onCellDoubleClick: noop,
-  onCellMouseOut: noop,
-  onCellMouseOver: noop,
-  onCellRightClick: noop,
+  onCellClick: null,
+  onCellDoubleClick: null,
+  onCellMouseOut: null,
+  onCellMouseOver: null,
+  onCellRightClick: null,
   sortBy: null,
   tooltip: null,
   widthType: '%',


### PR DESCRIPTION
Really weird bug where the onRowClick handler wasn't working in HD.

Tracked it down to some wacky stuff with imports in the built library. You expect that by not passing in `onCellClick` to a TableColumn, then `onClick` will equal `noop`. However, doing a breakpoint in browser at this point
```
  if (onClick && onClick !== noop) {
    eventHandlerProps.onClick = createEventHandler(onClick);
  }
```
in `getEventHandlerProps.js` demonstrates that despite both functions `onClick` and `noop` being `f () {}` in the javascript console, they are not equal.

Note that `onClick` is a function in the right panel.
![image](https://user-images.githubusercontent.com/15113350/206029330-ca9518a5-3610-4237-9825-fae659376f59.png)

![image](https://user-images.githubusercontent.com/15113350/206029378-1b0c9b3e-db6f-4e8c-ad1a-473d7b45bd35.png)

![image](https://user-images.githubusercontent.com/15113350/206029434-a31a2c05-13b4-4e46-8752-7b54a8c04b72.png)

Note that they are both noops.
![image](https://user-images.githubusercontent.com/15113350/206029524-bc001927-1a55-4eb2-bf27-f725964f0d0e.png)

Turns out by instead just setting the default function handler for Columns to be `null` resolves the issue since `null` will fail the first part of this if-statement. I have seen other usages of `null` for the default value for function handlers in tangelo so I figure it's probably gravy.

